### PR TITLE
Add capability to auto configure from chef install

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -5,7 +5,11 @@ In the fixie directory, run `bundle install --binstubs`
 
 Configuring fixie
 -------
-You need a fixie.conf file with the appropriate URIs and secrets for
+
+On chef server installs, fixie can read configuration information out
+of /etc/opscode, specifically the chef-server-running.json file.
+
+Otherwise, you will need a fixie.conf file with the appropriate URIs and secrets for
 accessing postgres and bifrost.
 
 The fixie.conf.example file contains examples from a instance of
@@ -19,8 +23,13 @@ private chef.
 
 Running fixie
 ------
-bin/fixie fixie.conf
 
+Start fixie with
+```shell
+bin/fixie fixie.conf
+```
+The config file is optional, leaving it out will attempt to read
+/etc/opscode for configuration.
 
 Inspecting objects
 ------

--- a/fixie.conf.example
+++ b/fixie.conf.example
@@ -1,10 +1,8 @@
 
 Fixie.configure do |mapper|
-  mapper.couchdb_uri = "http://localhost:5984"
-  mapper.couchdb_auth_database = 'opscode_account'
   mapper.authz_uri = "http://localhost:9463"
-  mapper.superuser_id = "fa84f0f5524a06baaa10b0f988ff2d8f"
-  mapper.sql_database = 'postgres://opscode_chef:3b2bb8affc0b87233130f820443aecca2061fadc6c0df16828233e433877ca1c552d1b9d40d3971f0e8c21fc4b7ff9471d91@localhost/opscode_chef'
+  mapper.superuser_id = "33d88ba14277f812a3ef3989869fb393"
+  mapper.sql_database = 'postgres://opscode_chef:6c6e1a140828be4ac406848e0b6a2ae1e9845e45ac4f48c790168c681c1b4217dc27ab99599130449a2437ab0d2a300bed5d@localhost/opscode_chef'
 end
 
 

--- a/lib/fixie/config.rb
+++ b/lib/fixie/config.rb
@@ -34,14 +34,12 @@ module Fixie
   # ==Example Config File:
   #
   #   Fixie.configure do |mapper|
-  #     mapper.couchdb_uri = 'http://db.example.com:5984'
-  #     mapper.database = 'opscode_account'
   #     mapper.authz_uri = 'http://authz.example.com:5959'
   #   end
   #
   class Config
     include Singleton
-    KEYS = [:couchdb_uri, :couchdb_auth_database, :authz_uri, :sql_database, :superuser_id, :pivotal_key]
+    KEYS = [:authz_uri, :sql_database, :superuser_id, :pivotal_key]
     KEYS.each { |k| attr_accessor k }
 
     def merge_opts(opts={})
@@ -83,9 +81,30 @@ module Fixie
       secrets_files = %w(private-chef-secrets.json)
       secrets = load_json_from_path([configdir], secrets_files)
 
+      pp :secrets=>secrets
+      
       config_files = %w(chef-server-running.json)
       config = load_json_from_path([configdir], config_files)
-     
+
+      pp :config=>config['private_chef'].keys
+
+      authz_config = config['private_chef']['oc_bifrost']
+      authz_vip = authz_config['vip']
+      authz_port = authz_config['port']
+      @authz_uri = "http://#{authz_vip}:#{authz_port}"
+      
+      @superuser_id = secrets['oc_bifrost']['superuser_id']
+
+      sql_config = config['private_chef']['postgresql']
+      
+      sql_user = sql_config['sql_user']
+      sql_pw = sql_config['sql_password']
+      sql_vip = sql_config['vip']
+      sql_port = sql_config['port']
+      
+      @sql_database = "postgres://#{sql_user}:#{sql_pw}@#{sql_vip}/opscode_chef"
+      
+      @pivotal_key = configdir + "pivotal.pem"
     end
 
     def load_json_from_path(pathlist, filelist)
@@ -94,7 +113,8 @@ module Fixie
         filelist.each do |file|
           configfile = path + file
           if configfile.file?
-            return parser.parse(json)
+            data = File.read(configfile)
+            return parser.parse(data)
           end
         end
       end

--- a/lib/fixie/config.rb
+++ b/lib/fixie/config.rb
@@ -78,22 +78,15 @@ module Fixie
     def load_from_pc(dir = "/etc/opscode")
       configdir = Pathname.new(dir)
 
-      secrets_files = %w(private-chef-secrets.json)
-      secrets = load_json_from_path([configdir], secrets_files)
-
-      pp :secrets=>secrets
-      
       config_files = %w(chef-server-running.json)
       config = load_json_from_path([configdir], config_files)
-
-      pp :config=>config['private_chef'].keys
 
       authz_config = config['private_chef']['oc_bifrost']
       authz_vip = authz_config['vip']
       authz_port = authz_config['port']
       @authz_uri = "http://#{authz_vip}:#{authz_port}"
       
-      @superuser_id = secrets['oc_bifrost']['superuser_id']
+      @superuser_id = authz_config['superuser_id']
 
       sql_config = config['private_chef']['postgresql']
       

--- a/lib/fixie/console.rb
+++ b/lib/fixie/console.rb
@@ -88,6 +88,10 @@ module Fixie
       if load_config_file
         puts "loading config: #{config_file}..."
         Kernel.load(config_file)
+      else
+        path = "/etc/opscode"
+        puts "loading config from #{path}"
+        Fixie::Config.instance.load_from_pc(path)
       end
 
       Fixie::Config.instance.merge_opts(options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,16 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'fixie/config'
 
+def load_from_config_example
+  # load from config file
+  config_file = "fixie.conf.example"
+  Kernel.load(config_file)
+end
+
+def load_from_opscode
+  Fixie::Config::instance.load_from_pc
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
@@ -17,8 +27,8 @@ RSpec.configure do |config|
   config.order = 'random'
 
   # configure specs
-  config_file = "fixie.conf.example"
-  Kernel.load(config_file)
+
+  load_from_opscode
   Fixie::Config.instance.merge_opts({})
   puts Fixie::Config.instance.to_text
 
@@ -28,3 +38,4 @@ RSpec.configure do |config|
   # class Users < Sequel::Model(:users) 
   require 'fixie'
 end
+


### PR DESCRIPTION
Read /etc/opscode and extract config data from config files there.

Also remove couchdb references, since a backport to chef 11 isn’t in the near term plan.

This makes fixie very easy to run in chef-server installations, since it should now just work

@mmzyk @adamedx @chef/server-team 