### PR TITLE
Remove aws-s3 from the dependency list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "aws-s3", :git => "git@github.com:opscode/aws-s3.git", :require => "aws/s3"
+#gem "aws-s3", :git => "git@github.com:opscode/aws-s3.git", :require => "aws/s3"
 
 # This is commented out because if we ever need to restore this we'll need to restore both properly to the same values to keep things working right.
 #gem "couchrest", :git => "git://github.com/opscode/couchrest.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,6 @@
-GIT
-  remote: git@github.com:opscode/aws-s3.git
-  revision: 182c8224f36590f34f85da8958b82a65b059026c
-  specs:
-    aws-s3 (0.6.2.1272580952)
-      builder
-      mime-types
-      xml-simple
-
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (3.2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     extlib (0.9.16)
@@ -44,14 +34,12 @@ GEM
     slop (3.6.0)
     uuidtools (2.1.5)
     wirble (0.1.3)
-    xml-simple (1.1.4)
     yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-s3!
   extlib
   highline
   pg (~> 0.16.0)


### PR DESCRIPTION
As far as I can tell, aws-s3 isn't actually needed, and with it being an ssh-accessible git repo, makes it a little hard to install without ssh keys and access to the relevant repo. This just removes that dependency.