### PR TITLE
Change name method to name_field

### DIFF
--- a/lib/fixie/sql_objects.rb
+++ b/lib/fixie/sql_objects.rb
@@ -75,8 +75,7 @@ module Fixie
       end
       # TODO figure out model for write access
 
-      # for objects whose name isn't the same as the field.
-      def self.name(field)
+      def self.name_field(field)
         fundef = "def name; @data.#{field}; end"
         self.class_eval(fundef)
       end
@@ -164,7 +163,7 @@ module Fixie
       def initialize(data)
         super(data)
       end
-      name :username
+      name_field :username
       ro_access :id, :authz_id, :last_updated_by, :created_at, :updated_at, :username, :email, :public_key, :pubkey_version, :serialized_object, :external_authentication_uid, :recovery_authentication_enabled, :admin, :hashed_password, :salt, :hash_type
     end
     class Client < SqlObject


### PR DESCRIPTION
This prevents a collision with the name method used on classes to show their
name (e.g. Object.name == "Object"), which in turn is used by pry to identify
the names of classes. This commit makes the 'ls' command work in pry once
more.