### PR TITLE
Ma/fixup perms

### DIFF
--- a/doc/AccessingSQL.md
+++ b/doc/AccessingSQL.md
@@ -5,7 +5,22 @@ Basics:
 Underneath everything is the Ruby Sequel library; there are a number
 of ways to access it.
 
-Check out http://ricostacruz.com/cheatsheets/sequel.html and 
+Check out http://ricostacruz.com/cheatsheets/sequel.html or the Sequel
+gem docs for details of the sequel library.
+
+Many objects in fixie have the accessor inner, which exposes the
+Sequel selector. This includes:
+* The constants ORGS, USERS, ASSOCIATIONS, and INVITES
+```ruby
+ORGS.inner.first
+#< @values={:id=>"7ddaee6b42e8f6a0a8e9d5d5efe644f8", :authz_id=>"f46b2e53869968ce115b97d2fd8bfee0", :name=>"ponyville", :full_name=>"ponyville", :assigned_at=>2015-07-21 18:22:34 UTC, :last_updated_by=>"08076ed32f7d5c62721607dd2c309c55", :created_at=>2015-07-21 18:22:34 UTC, :updated_at=>2015-07-21 18:22:34 UTC}>
+```
+* Any of the by_XXXX accessors
+```ruby
+ORGS['
+
+
+```
 
 
 
@@ -34,3 +49,20 @@ now = Sequel.function(:NOW)
 ASSOCS.inner.insert(:org_id=>o.id, :user_id=>u.id, :last_updated_by=>pivotal.authz_id,
 	:created_at=>now, :updated_at=>now )
 ```
+
+
+* Fixing a group that lost its authz object.
+We've seen the users group in hosted loose it's authz entry
+
+```ruby
+a = Fixie::AuthzApi.new
+# create a new authz group
+g = a.post("groups",{})
+# check that only one group is returned
+ORGS['acme'].groups.by_name('users').inner.all
+# alter the group and insert the new authz id
+ORGS['acme'].groups.by_name('users').inner.update(:authz_id=>g.id)
+```
+
+This does not add the users back to the usergs group, or re-add users
+all the acls that used to have the users group in them.

--- a/doc/BulkFixup.md
+++ b/doc/BulkFixup.md
@@ -1,0 +1,33 @@
+Restoring acl permissions globally
+============
+
+If a key group is deleted (such as users)
+
+* Verify that the org has issues
+
+* Create/restore the group
+(TBW)
+
+* Add the users/groups back to the group
+(TBW)
+
+* Set the group ACL appropriately
+```ruby
+users_group.ace_add([:create,:read,:update,:delete], org.groups['admins'])
+users_group.ace_add([:create,:read,:update,:delete], USERS['pivotal'])
+``
+
+* Restore users to the appropriate container ACLs
+```ruby
+org = ORGS[THE_ORG]
+cl = %w(cookbooks data nodes roles environments policies policy_groups cookbook_artifacts)
+cl.each {|c| o.containers[c].ace_add([:create,:read,:update,:delete], org.groups['users']) }
+%w(clients).each { |c| org.containers[c].ace_add([:read,:delete], org.groups['users']) }
+%w(groups containers).each { |c| org.containers[c].ace_add([:read], org.groups['users']) }
+%w(sandboxes).each { |c| org.containers[c].ace_add([:create], org.groups['users']) }
+```
+
+* Then update the objects from the containers:
+```ruby
+Fixie::BulkEditPermissions::copy_from_containers(org)
+```

--- a/lib/chef_fixie.rb
+++ b/lib/chef_fixie.rb
@@ -23,5 +23,6 @@ require_relative 'chef_fixie/sql_objects'
 
 # This doesn't work because of initialization order, figure it out.
 require_relative 'chef_fixie/check_org_associations'
+require_relative 'chef_fixie/bulk_edit_permissions'
 
 Sequel.extension :inflector

--- a/lib/chef_fixie/bulk_edit_permissions.rb
+++ b/lib/chef_fixie/bulk_edit_permissions.rb
@@ -45,7 +45,13 @@ module ChefFixie
       pivotal = users['pivotal'].authz_id
       errors = Hash.new({})
       org.each_authz_object do |object|
-        acl = object.acl_raw
+        begin 
+          acl = object.acl_raw
+        rescue RestClient::ResourceNotFound=>e
+          puts "#{object.class} '#{object.name}' id '#{object.id}' missing authz info"
+          # pp :object=>object, :e=>e
+          next
+        end
         broken_acl = {}
         # the one special case
         acl.each do |k,v|

--- a/lib/chef_fixie/bulk_edit_permissions.rb
+++ b/lib/chef_fixie/bulk_edit_permissions.rb
@@ -1,0 +1,151 @@
+#
+# Copyright (c) 2015 Chef Software Inc.
+# License :: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Anderson <mark@chef.io>
+#
+require 'sequel'
+
+require_relative 'config.rb'
+require_relative 'authz_objects.rb'
+require_relative 'authz_mapper.rb'
+
+require 'pp'
+
+module ChefFixie
+  module BulkEditPermissions
+    def self.orgs
+      @orgs ||= ChefFixie::Sql::Orgs.new
+    end
+    def self.users
+      @users ||= ChefFixie::Sql::Users.new
+    end
+    def self.assocs
+      @assocs ||= ChefFixie::Sql::Associations.new
+    end
+    def self.invites
+      invites ||= ChefFixie::Sql::Invites.new
+    end
+
+    def self.check_permissions(org)
+      org = orgs[org] if org.is_a?(String)
+      admins = org.groups['admins'].authz_id
+      pivotal = users['pivotal'].authz_id
+      errors = Hash.new({})
+      org.each_authz_object do |object|
+        acl = object.acl_raw
+        broken_acl = {}
+        # the one special case
+        acl.each do |k,v|
+          list = []
+          list << "pivotal" if !v['actors'].member?(pivotal)
+          # admins doesn't belong to the billing admins group
+          if object.class != ChefFixie::Sql::Group || object.name != 'billing-admins'
+            list << "admins" if !v['groups'].member?(admins)
+          end
+          broken_acl[k] = list if !list.empty?
+        end
+        if !broken_acl.empty?
+          classname = object.class
+          errors[classname] = {} if !errors.has_key?(classname)
+          errors[classname][object.name] = broken_acl
+        end
+      end
+      return errors
+    end
+
+    def self.ace_add(list, ace_type, entity)
+      list.each do |item|
+        if item.respond_to?(:ace_add)
+          item.ace_add(ace_type, entity)
+        else
+          puts "item.class is not a native authz type"
+          return
+        end
+      end
+    end
+    def self.ace_delete(list, ace_type, entity)
+      list.each do |item|
+        if item.respond_to?(:ace_delete)
+          item.ace_delete(ace_type, entity)
+        else
+          puts "item.class is not a native authz type"
+          return
+        end
+      end
+    end
+
+    def self.do_all_objects(org)
+      org = orgs[org] if org.is_a?(String)
+
+      containers = org.containers.all(:all)
+      # Maybe we should fix up containers first?
+      # fix up objects in containers
+      containers.each do |container|
+        # TODO Write some tests to validate that this stuff
+        # works, since it depends on a lot of name magic...
+        object_type = container.name.to_sym
+#        raise Exception "No such object_type #{object_type}" unless org.respond_to?(object_type)
+        objects = org.send(object_type).all(:all)
+        if block_given?
+          yield objects
+        end
+      end
+    end
+
+    def self.ace_add_all(org, ace_type, entity)
+      org = orgs[org] if org.is_a?(String)
+      org.each_authz_object_by_class do |objects|
+        ace_add(objects, ace_type, entity)
+      end
+    end
+
+    def self.ace_delete_all(org, ace_type, entity)
+      org = orgs[org] if org.is_a?(String)
+      org.each_authz_object_by_class do |objects|
+        ace_delete(objects, ace_type, entity)
+      end
+    end
+
+    def self.add_admin_permissions(org)
+      org = orgs[org] if org.is_a?(String)
+      # rework when ace add takes multiple items...
+      admins = org.groups['admins']
+      pivotal = users['pivotal']
+      org.each_authz_object do |object|
+        object.ace_add(:all, pivotal)
+        if object.class != ChefFixie::Sql::Group || object.name != 'billing-admins'
+          object.ace_add(:all, admins)
+        end
+      end
+    end
+
+    def self.copy_from_containers(org)
+      org = orgs[org] if org.is_a?(String)
+
+      containers = org.containers.all(:all)
+      containers.each do |c|
+        # don't mess with containers and groups, they are special
+        next if c.name == "containers" || c.name == "groups"
+        org.objects_by_container_type(c.name).each do |obj|
+          obj.acl_add_from_object(c)
+          puts "#{obj.name} from #{c.name}"
+        end
+      end
+      return
+    end
+
+  end
+end


### PR DESCRIPTION
This adds permission fixup code, including a check routine and a tool to copy permissions from containers.

Requires tests before merging, but may be useful in the interim

@paulmooring 