### PR TITLE
Work correctly with renamed global_admins group

### DIFF
--- a/lib/chef_fixie/sql_objects.rb
+++ b/lib/chef_fixie/sql_objects.rb
@@ -145,8 +145,12 @@ module ChefFixie
       def global_admins
         name = self.name
         global_admins_name = "#{name}_global_admins"
-        ChefFixie::Sql::Groups.new["#{name}_global_admins"]
+        read_access_name = "#{name}_read_access_group"
+        ChefFixie::Sql::Groups.new[global_admins_name] || \
+          ChefFixie::Sql::Groups.new[read_access_name]
       end
+
+      alias read_access_group global_admins
 
       # Iterators for objects in authz; using containers to enumerate things
       # It might be better to metaprogram this up instead,


### PR DESCRIPTION
This change will look for ORGNAME_read_access_group if it doesn't find the
ORGNAME_global_admins group when looking up the global admins group. It also
aliases the method so ORGS['foo'].read_access_group works as well.

Fixes #17
