### PR TITLE
Use latest chef-client 15(15.12.22) and bundler 1.17

### DIFF
--- a/chef_fixie.gemspec
+++ b/chef_fixie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "chef", ">= 11.12.2"
+  spec.add_runtime_dependency "chef", "~> 15.2"
   spec.add_runtime_dependency "ffi-yajl", ">= 1.2.0"
   spec.add_runtime_dependency "pg", "~> 0.17", ">= 0.17.1"
   spec.add_runtime_dependency "pry", "~> 0.10.1"
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "uuidtools", "~> 2.1", ">= 2.1.3"
   spec.add_runtime_dependency 'veil'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "rspec", "~> 0"
 end


### PR DESCRIPTION
Fixie pulled the latest chef. Since chef-server depends on fixie, the latest chef-client got pulled in with fixie, despite of what versions are pinned in chef-server.

This is an attempt to control the versions of chef-client  being installed in chef-server.

A better way to do this might be to define fixie dep in gemfile instead of pulling it from omniubs-software.

Passing build of chef-server :https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1357