### PR TITLE
Unpin chef to include in chef-server

### DIFF
--- a/chef_fixie.gemspec
+++ b/chef_fixie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "chef", "~> 15.2"
+  spec.add_runtime_dependency "chef", ">= 15.2"
   spec.add_runtime_dependency "ffi-yajl", ">= 1.2.0"
   spec.add_runtime_dependency "pg", "~> 0.17", ">= 0.17.1"
   spec.add_runtime_dependency "pry", "~> 0.10.1"
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "uuidtools", "~> 2.1", ">= 2.1.3"
   spec.add_runtime_dependency 'veil'
 
-  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "rspec", "~> 0"
 end


### PR DESCRIPTION
Rely on the pin in chef-server to not blow up the world. Otherwise this
becomes a blocker for upgrading chef in chef-server later.

Signed-off-by: Tim Smith <tsmith@chef.io>