### PR TITLE
Adjust sequel dependency to allow for new versions

### DIFF
--- a/chef_fixie.gemspec
+++ b/chef_fixie.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ffi-yajl", ">= 1.2.0"
   spec.add_runtime_dependency "pg", "~> 1.2", ">= 1.2.3"
   spec.add_runtime_dependency "pry", "~> 0.13"
-  spec.add_runtime_dependency "sequel", "~> 4.11"
+  spec.add_runtime_dependency "sequel"
   spec.add_runtime_dependency "uuidtools", "~> 2.1", ">= 2.1.3"
   spec.add_runtime_dependency "veil"
 end


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

## Description
The knife-ec-backup requires the updated version of Sequel to function properly.

The PR #57 fixes the version of sequel to 5.9. This PR removes the version fixing all together, so that we don't have to update all the dependencies every time there is an update.

## Related Issue
chef/chef-server#2835
chef/knife-ec-backup#164
https://github.com/chef/fixie/pull/57

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
